### PR TITLE
Update Readme and CMake files for MinGW compartibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ make
 [make install]
 ```
 
+Note: for build on Windows you need to specify compiler and use specific for this compiler `make` command. The following example is for MinGW compiler:
+```
+mkdir build
+cd build
+cmake [-DCMAKE_BUILD_TYPE={Release|Debug|Coverage|ASan|ASanDbg|MemSan|MemSanDbg|Check}]\
+      [-DBUILD_FAST=ON]\
+      [-DBASH_PLATFORM={BASH_32|BASH_64|BASH_AVX2|BASH_AVX512|BASH_NEON}]\
+      -G "MinGW Makefiles"\
+      ..
+mingw32-make
+[mingw32-make test]
+[mingw32-make install]
+``` 
+
 Build types (`Release` by default):
    
 *  `Coverage` — test coverage;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,13 +85,15 @@ if(BUILD_SHARED_LIBS)
     if(MSVC)
       # disable security warnings for sprintf() in bee2.c
       add_definitions(/D _CRT_SECURE_NO_WARNINGS)
+      add_library(bee2 SHARED ${src} 
+        ../win/bee2.def
+        ../img/bee2.bmp
+        ../win/bee2.rc
+        ../win/bee2.c
+      )
+    else()
+      add_library(bee2 SHARED ${src})
     endif()
-    add_library(bee2 SHARED ${src} 
-      ../win/bee2.def
-      ../img/bee2.bmp
-      ../win/bee2.rc
-      ../win/bee2.c
-    )
   endif()
 
   target_link_libraries(bee2 ${libs})


### PR DESCRIPTION
CMakeLists.txt is updated for MinGW compartibility.
Process of building with MinGW compiler is described in Readme.
Path to compiler should be in $PATH$ system variable. 
GNU-compartible shell should be used (I used Bash shell from Git installation)
