### PR TITLE
Fix for loop initial declaration

### DIFF
--- a/cmd/core/whereami.c
+++ b/cmd/core/whereami.c
@@ -262,8 +262,9 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 {
   int length = -1;
   FILE* maps = NULL;
+  int r;
 
-  for (int r = 0; r < WAI_PROC_SELF_MAPS_RETRY; ++r)
+  for (r = 0; r < WAI_PROC_SELF_MAPS_RETRY; ++r)
   {
     maps = fopen(WAI_PROC_SELF_MAPS, "r");
     if (!maps)


### PR DESCRIPTION
GNU 4.8.5 CentOS 7

```
/bee2/cmd/core/whereami.c:266:3: error: 'for' loop initial declarations are only allowed in C99 mode
   for (int r = 0; r < WAI_PROC_SELF_MAPS_RETRY; ++r)
```
