### PR TITLE
fix OOB write in jsonArrDec

### DIFF
--- a/include/bee2/core/json.h
+++ b/include/bee2/core/json.h
@@ -80,9 +80,10 @@ JSON-код представляет собой элемент с любым ч�
 \code
 	json_elem_t elem;
 	size_t c;
+	size_t elems_count = 1;
 	size_t size;
 	...
-	c = jsonArrDec(&elem, 1, json, count);
+	c = jsonArrDec(&elem, &elems_count, 1, json, count);
 	...
 	c = jsonSizeDec(&size, elem.json, elem.count);
 \endcode
@@ -167,15 +168,21 @@ size_t jsonObjDec(
 /*!	\brief Декодирование массива
 
 	Декодируется массив JSON, заданный кодом [count]json. В результате
-	декодирования определяются вложенные в массив элементы [elems_count?]elems.
+	декодирования определяются вложенные в массив элементы elems.
 	\pre Указатель json корректен.
-	\pre Любой из указателей elems и count может быть нулевым.
+	\pre Указатель elems может быть нулевым и тогда элементы не возвращаются.
+	\pre Указатель elems_count может быть нулевым и тогда число элементов
+	не возвращается.
+	\pre Если elems не нулевой, то elems_capacity задает число элементов elems.
 	\return Обработанная при декодировании длина JSON-кода (включая	
 	предваряющие и завершающие пробелы) или SIZE_MAX в случае ошибки.
+	\remark Если число элементов массива превышает elems_capacity, то
+	возвращается SIZE_MAX.
 */
 size_t jsonArrDec(
-	json_elem_t elems[],	/*!< [out] элементы */
-	size_t* elems_count,	/*!< [out] число элементов */
+	json_elem_t elems[],		/*!< [out] элементы */
+	size_t* elems_count,		/*!< [out] число элементов */
+	size_t elems_capacity,	/*!< [in] емкость массива элементов */
 	const char json[],		/*!< [in] код */
 	size_t count			/*!< [in] длина кода */
 );

--- a/src/core/json.c
+++ b/src/core/json.c
@@ -355,7 +355,8 @@ size_t jsonObjDec(json_elem_t elems[], const char json[], size_t count,
 */
 
 static size_t jsonArrParse(json_elem_t* elem, json_elem_t elems[], 
-	size_t* elems_count, const char json[], size_t count, size_t depth)
+	size_t* elems_count, size_t elems_capacity, const char json[], size_t count,
+	size_t depth)
 {
 	size_t c;
 	size_t c1;
@@ -371,7 +372,7 @@ static size_t jsonArrParse(json_elem_t* elem, json_elem_t elems[],
 	if ((c = jsonWsDec(json, count)) == SIZE_MAX)
 		return SIZE_MAX;
 	json += c, count -= c;
-	if (json[0] != '[')
+	if (count == 0 || json[0] != '[')
 		return SIZE_MAX;
 	if (elem)
 		elem->json = json, elem->count = c;
@@ -387,6 +388,8 @@ static size_t jsonArrParse(json_elem_t* elem, json_elem_t elems[],
 		// сохранить элемент
 		if (elems)
 		{
+			if (ec >= elems_capacity)
+				return SIZE_MAX;
 			ASSERT(memIsValid(elems, (ec + 1) * sizeof(json_elem_t)));
 			memCopy(elems + ec, &e, sizeof(json_elem_t));
 		}
@@ -411,10 +414,10 @@ static size_t jsonArrParse(json_elem_t* elem, json_elem_t elems[],
 	return c + jsonWsDec(json, count);
 }
 
-size_t jsonArrDec(json_elem_t elems[], size_t* elems_count, const char json[],
-	size_t count)
+size_t jsonArrDec(json_elem_t elems[], size_t* elems_count,
+	size_t elems_capacity, const char json[], size_t count)
 {
-	return jsonArrParse(0, elems, elems_count, json, count, 0);
+	return jsonArrParse(0, elems, elems_count, elems_capacity, json, count, 0);
 }
 
 /*
@@ -440,7 +443,7 @@ static size_t jsonElemParse(json_elem_t* elem, const char json[], size_t count,
 	if (json[0] == '{')
 		c1 = jsonObjParse(elem, json, count, depth + 1);
 	else if (json[0] == '[')
-		c1 = jsonArrParse(elem, 0, 0, json, count, depth + 1);
+		c1 = jsonArrParse(elem, 0, 0, 0, json, count, depth + 1);
 	else if (json[0] == '"')
 		c1 = jsonStrParse(elem, json, count);
 	else if ('0' <= json[0] && json[0] <= '9')

--- a/test/core/json_test.c
+++ b/test/core/json_test.c
@@ -195,19 +195,23 @@ static bool_t jsonTestArr()
 	size_t count;
 	size_t pos;
 	// корректные объекты
-	count = jsonArrDec(0, &size, jsons[0], strLen(jsons[0]));
+	count = jsonArrDec(0, &size, 0, jsons[0], strLen(jsons[0]));
 	if (count != strLen(jsons[0]) || size != 0)
 		return FALSE;
 	for (pos = 1; pos <= 5; ++pos)
 	{
-		count = jsonArrDec(elems, &size, jsons[pos], strLen(jsons[pos]));
+		count = jsonArrDec(elems, &size, COUNT_OF(elems), jsons[pos],
+			strLen(jsons[pos]));
 		if (count != strLen(jsons[pos]) || size != 7 - pos)
 			return FALSE;
 	}
+	count = jsonArrDec(elems, &size, 1, jsons[1], strLen(jsons[1]));
+	if (count != SIZE_MAX)
+		return FALSE;
 	// некорректные
 	for (; pos < COUNT_OF(jsons); ++pos)
 	{
-		count = jsonArrDec(0, &size, jsons[pos], strLen(jsons[pos]));
+		count = jsonArrDec(0, &size, 0, jsons[pos], strLen(jsons[pos]));
 		if (count != SIZE_MAX)
 			return FALSE;
 	}


### PR DESCRIPTION
Раньше `jsonArrParse()` записывала элементы в `elems[]`, не зная размер переданного массива. Если JSON-массив содержал больше элементов, чем выделено вызывающей стороной, могла
  произойти запись за границы буфера.